### PR TITLE
Pin os to ubuntu 22

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-codepropertygraph:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
`sbt` is removed in `ubuntu-24/latest`.
Refer https://github.com/actions/setup-java/issues/712