### PR TITLE
Fork join opt

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/StatsCollector.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/StatsCollector.scala
@@ -13,6 +13,10 @@ object StatsLogger extends DataLogger {
   ): Unit = { logger.foreach(log => log.initiateNewStage(stageName, stageFullName, additionalMetaDataToLog)) }
 
   def endLastStage(): Unit = { logger.foreach(log => log.endLastStage()) }
+
+  def justLogMessage(message: String): Unit = {
+    logger.foreach(log => log.justLogMessage(message))
+  }
 }
 
 trait DataLogger {
@@ -25,4 +29,6 @@ trait DataLogger {
   ): Unit
 
   def endLastStage(): Unit
+
+  def justLogMessage(message: String): Unit
 }


### PR DESCRIPTION
When we look at the logs for each thread and the evaluation time for each task. It seems that while running the tasks in parallel using the `parallel` feature of collections, it's not evenly distributing the tasks. Haven't gone into the details of why its happening that way. Tried with `Future` and it worked well. 